### PR TITLE
21 Add adminclaim and hide users from non admins

### DIFF
--- a/api/controllers/admin_controller.go
+++ b/api/controllers/admin_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"context"
 	"dat250-project-group-1/feedapp/models"
 	"net/http"
 
@@ -46,10 +47,19 @@ func MakeAdmin(c *gin.Context) {
 	}
 
 	var userToEdit models.User
-	res = db.Model(&userToEdit).Where("ID = ?", c.Param("uid")).Update("IsAdmin",true)
+	res = db.Model(&userToEdit).Where("ID = ?", c.Param("uid")).Update("IsAdmin", true)
 
 	if res.Error != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "count not edit user"})
+		return
+	}
+
+	auth := c.MustGet("auth").(*auth.Client)
+
+	claims := map[string]interface{}{"admin": true}
+	err := auth.SetCustomUserClaims(context.Background(), userRecord.UID, claims)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "error setting custom claim"})
 		return
 	}
 

--- a/api/main.go
+++ b/api/main.go
@@ -23,7 +23,7 @@ func main() {
 	router.Use(static.Serve("/", static.LocalFile("./static", true)))
 
 	// Enable cors support
-	//router.Use(middleware.Cors)
+	router.Use(middleware.Cors)
 
 	// Registrer middlewares
 	router.Use(func(c *gin.Context) {

--- a/app/lib/src/api/repository.dart
+++ b/app/lib/src/api/repository.dart
@@ -6,8 +6,8 @@ import 'package:app/src/models/user.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
-//const API_URL = "http://localhost:8080";
-const API_URL = "";
+const API_URL = "http://localhost:8080";
+//const API_URL = "";
 
 class Repository {
   Future<String> get token async {

--- a/app/lib/src/auth/auth_service.dart
+++ b/app/lib/src/auth/auth_service.dart
@@ -17,16 +17,21 @@ class AuthService with ChangeNotifier {
   final _repository = new Repository();
   Status _status = Status.Uninitialized;
   String _errorMessage = "";
+  bool _isAdmin = false;
 
   Status get status => _status;
+
   String get errorMessage => _errorMessage;
+
+  bool get isAdmin => _isAdmin;
 
   AuthService() {
     FirebaseAuth.instance.userChanges().listen((User user) async {
       if (user != null) {
         var prefs = await SharedPreferences.getInstance();
-        var token = await user.getIdToken();
-        prefs.setString('token', token);
+        var token = await user.getIdTokenResult(true);
+        _isAdmin = token.claims['admin'] ?? false;
+        prefs.setString('token', token.token);
         _repository.postUser();
         changeStatus(Status.Authenticated);
       } else {

--- a/app/lib/src/views/main_screen.dart
+++ b/app/lib/src/views/main_screen.dart
@@ -1,8 +1,10 @@
+import 'package:app/src/auth/auth_service.dart';
 import 'package:app/src/views/my_polls.dart';
 import 'package:app/src/views/public_polls.dart';
 import 'package:app/src/views/users.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
 
 class MainScreen extends StatefulWidget {
   @override
@@ -26,6 +28,8 @@ class _MainScreenState extends State<MainScreen> {
 
   @override
   Widget build(BuildContext context) {
+    AuthService authService = context.watch<AuthService>();
+
     return Scaffold(
       body: _views[_selectedIndex],
       bottomNavigationBar: BottomNavigationBar(
@@ -38,10 +42,11 @@ class _MainScreenState extends State<MainScreen> {
             icon: Icon(Icons.analytics),
             label: "My polls",
           ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.people),
-            label: "Users",
-          ),
+          if (authService.isAdmin)
+            BottomNavigationBarItem(
+              icon: Icon(Icons.people),
+              label: "Users",
+            ),
         ],
         currentIndex: _selectedIndex,
         onTap: _onItemTapped,

--- a/app/lib/src/views/public_polls.dart
+++ b/app/lib/src/views/public_polls.dart
@@ -16,8 +16,8 @@ class _PublicPollsState extends State<PublicPolls> {
   GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey();
   Poll searched;
 
-  Future<void> _showPollDialog(
-      BuildContext context, Future<Null> Function(String code) getPoll) async {
+  Future<void> _showPollDialog(BuildContext context,
+      Future<Null> Function(String code) getPoll) async {
     return showDialog<void>(
         context: context,
         barrierDismissible: false,
@@ -75,6 +75,13 @@ class _PublicPollsState extends State<PublicPolls> {
               ),
               onPressed: () {
                 authService.changeStatus(Status.Login);
+              },
+            ),
+          if (authService.status == Status.Authenticated)
+            MaterialButton(
+              child: Text("Sign out"),
+              onPressed: () async {
+                await authService.signOut();
               },
             )
         ],

--- a/app/lib/src/views/users.dart
+++ b/app/lib/src/views/users.dart
@@ -1,5 +1,4 @@
 import 'package:app/src/api/api_service.dart';
-import 'package:app/src/auth/auth_service.dart';
 import 'package:app/src/widgets/user_list.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -18,19 +17,9 @@ class _UsersState extends State<Users> {
 
   @override
   Widget build(BuildContext context) {
-    AuthService authService = context.watch<AuthService>();
-
     return Scaffold(
       appBar: AppBar(
         title: Text("Users"),
-        actions: [
-          MaterialButton(
-            child: Text("Sign out"),
-            onPressed: () async {
-              await authService.signOut();
-            },
-          )
-        ],
       ),
       floatingActionButton: FloatingActionButton(
         child: Icon(Icons.add),


### PR DESCRIPTION
Fixes #21 

La til adminClaim på admins, slik at det er lett å finne ut om man er admin eller ikke.

Måtte skru på cors og endre apiurl for å kunne kjøre lokalt igjen, er vel best å ha det sånn i source coden, siden det er sånn vi utvikler